### PR TITLE
petsc 3.15 merged VecScatter into PetscSF

### DIFF
--- a/DaetkPetscVec.h
+++ b/DaetkPetscVec.h
@@ -38,7 +38,17 @@ namespace PetscVecOperators
   Daetk::real min(const Daetk::Petsc::Vec& v);
 }
 
-namespace Daetk 
+#include "petscversion.h"
+// petsc 3.15 merged VecScatter into PetscSF. Private variables were removed.
+#if (\
+  (PETSC_VERSION_MAJOR > 3) \
+  || \
+  (PETSC_VERSION_MAJOR == 3 && PETSC_VERSION_MINOR >= 15) \
+)
+  #define _p_VecScatter _p_PetscSF
+#endif
+
+namespace Daetk
 {
 namespace Petsc
 {


### PR DESCRIPTION
Private variables like `_p_VecScatter` were removed.

I'm not sure if there's a better way to get at this without private APIs, because public names like `VecScatter` work fine as aliases to the new type

testing in https://github.com/conda-forge/daetk-feedstock/pull/6