### PR TITLE
remove use of deprecated `register` storage class

### DIFF
--- a/CMRVec.h
+++ b/CMRVec.h
@@ -45,7 +45,7 @@ public:
   template <class RHS>
   CMRVec& operator+=(const Pete::Expression<RHS> &rhs)
   {
-    register int index=base_,end=base_+dim_;
+    int index=base_,end=base_+dim_;
     T* lhs=p_;
     for(index=base_;index<end;index++)
       {
@@ -58,7 +58,7 @@ public:
   template <class RHS>
   CMRVec& operator=(const Pete::Expression<RHS> &rhs)
   {
-    register int index=base_,end=base_+dim_;
+    int index=base_,end=base_+dim_;
     T* lhs=p_;
     for(index=base_;index<end;index++)
       {
@@ -71,7 +71,7 @@ public:
   template <class RHS>
   CMRVec& operator-=(const Pete::Expression<RHS> &rhs)
   {
-    register int index=base_,end=base_+dim_;
+    int index=base_,end=base_+dim_;
     T* lhs=p_;
     for(index=base_;index<end;index++)
       {

--- a/FLCBDF.cpp
+++ b/FLCBDF.cpp
@@ -897,8 +897,8 @@ bool FLCBDF::step(const real& tout,real& tStep,Vec& solutionAtTStep, Vec& stp)
 
 void FLCBDF::updateCoefficients()
 {
-  register int i;
-  register real temp1(0),temp2(0);
+  int i;
+  real temp1(0),temp2(0);
   //The following coefficients are constants throughout the integration:
   //betaNp1[0]=1.0, sigmaNp1[0]=1.0, gammaNp1[0]=0.0, alphaNp1[0]=1.0;
  
@@ -1201,7 +1201,7 @@ void FLCBDF::chooseOrderForStep()
   //the following terms will be estimates of the remainder terms of 
   //Taylor series expansions of orders k-2,k-1,k, and k+1
 
-  register real termkm2=12345,termkm1=12345,termk=12345,termkp1=12345,errorkm2=12345,errorkm1=12345,errork=12345,errorkp1=12345;
+  real termkm2=12345,termkm1=12345,termk=12345,termkp1=12345,errorkm2=12345,errorkm1=12345,errork=12345,errorkp1=12345;
 
   //compute error estimates
    
@@ -1526,7 +1526,7 @@ void FLCBDF::interpolant(const real& tout,Vec& yAtTout,Vec& yPAtTout)
   //the implementation is a bit tricky because it uses coefficient data
   //to compute t-t_i, i=n,...n-k+2. This eliminates the need to store t_i's
   //updateCoefficients();
-  register real toutminustn,D,C,gamma,psiN[7];
+  real toutminustn,D,C,gamma,psiN[7];
   for (i=0;i<7;i++)
     psiN[i] = psiNp1[i];
   updateCoefficients();
@@ -1569,8 +1569,8 @@ bool FLCBDF::calculateSteadyStateSolution(Vec& solutionAtTout, Vec& sp, real sst
 {
   data->startUserStep();
 
-  register bool solverFailed;
-  register real tCurrent,tout=1.0e6;//got to set tout to something
+  bool solverFailed;
+  real tCurrent,tout=1.0e6;//got to set tout to something
   real nrm2_sp0 = nrm2(sp);
 
   if (firstCallToSolver) 
@@ -1607,8 +1607,8 @@ bool FLCBDF::calculateSolution(const real& tout,Vec& solutionAtTout, Vec& sp)
 {
   data->startUserStep();
 
-  register bool solverFailed;
-  register real tCurrent;
+  bool solverFailed;
+  real tCurrent;
   if (firstCallToSolver) 
     { 
       if (solverFailed=takeInitialSteps(tout,tCurrent,solutionAtTout,sp))

--- a/FLCBDF_lite.cpp
+++ b/FLCBDF_lite.cpp
@@ -489,8 +489,8 @@ bool FLCBDF_lite::checkError(const Vec& y)
 
 void FLCBDF_lite::updateCoefficients()
 {
-  register int i;
-  register real temp1(0),temp2(0);
+  int i;
+  real temp1(0),temp2(0);
   //The following coefficients are constants throughout the integration:
   //betaNp1[0]=1.0, sigmaNp1[0]=1.0, gammaNp1[0]=0.0, alphaNp1[0]=1.0;
  
@@ -699,7 +699,7 @@ void FLCBDF_lite::chooseOrderForStep()
   //the following terms will be estimates of the remainder terms of 
   //Taylor series expansions of orders k-2,k-1,k, and k+1
 
-  register real termkm2=12345,termkm1=12345,termk=12345,termkp1=12345,errorkm2=12345,errorkm1=12345,errork=12345,errorkp1=12345;
+  real termkm2=12345,termkm1=12345,termk=12345,termkp1=12345,errorkm2=12345,errorkm1=12345,errork=12345,errorkp1=12345;
 
   //compute error estimates
    
@@ -898,7 +898,7 @@ void FLCBDF_lite::interpolant(const real& tout,Vec& yAtTout,Vec& yPAtTout)
   //the implementation is a bit tricky because it uses coefficient data
   //to compute t-t_i, i=n,...n-k+2. This eliminates the need to store t_i's
   //updateCoefficients();
-  register real toutminustn,D,C,gamma,psiN[7];
+  real toutminustn,D,C,gamma,psiN[7];
   for (i=0;i<7;i++)
     psiN[i] = psiNp1[i];
   updateCoefficients();

--- a/pdetk/DivKgrad.h
+++ b/pdetk/DivKgrad.h
@@ -475,7 +475,7 @@ inline void DivKgrad<BC,nv>::setDFlux_x(const Vec* K, const Vec* Rho, const Vec*
   //it's very important that the compiler be able to unroll these
   for (int vi=0;vi<nv;vi++)
     {
-      register real rhox=Rhox(Rho[vi]),
+      real rhox=Rhox(Rho[vi]),
 	grad=DpDx(P[vi]) + rhox*this->gx,
 	kx=this->viscosity_ratio[vi]*Kx(K[vi],grad),
 	kxGrad=kx*grad,

--- a/pdetk/DivKgradUG.h
+++ b/pdetk/DivKgradUG.h
@@ -496,7 +496,7 @@ inline void DivKgradUG<BC,nv>::setDFlux_x(const Vec* K, const Vec* Rho, const Ve
   //it's very important that the compiler be able to unroll these
   for (int vi=0;vi<nv;vi++)
     {
-      register real rhox=Rhox(Rho[vi]),
+      real rhox=Rhox(Rho[vi]),
 	grad=DpDx(P[vi]) + rhox*this->gx,
 	kx=this->viscosity_ratio[vi]*Kx(K[vi],grad),
 	kxGrad=kx*grad,

--- a/pdetk/DivKgradUGMM.h
+++ b/pdetk/DivKgradUGMM.h
@@ -503,7 +503,7 @@ inline void DivKgradUGMM<BC,nv>::setDFlux_x(const Vec* K, const Vec* Rho, const 
   //it's very important that the compiler be able to unroll these
   for (vi=0;vi<nv;vi++)
     {
-      register real rhox=Rhox(Rho[vi]),
+      real rhox=Rhox(Rho[vi]),
 	grad=DpDx(P[vi]) + rhox*gx,
 	kx=viscosity_ratio[vi]*Kx(K[vi],grad),
 	kxGrad=kx*grad,

--- a/pdetk/TwopCDM.h
+++ b/pdetk/TwopCDM.h
@@ -289,7 +289,7 @@ bool TwopCDMSP<PROB,JAC>::yPrimeValue(const real &t,const  Vec& y,Vec& yp)
   
   pc.adjustBC(t);
 
-  register real a,b,c,d,det;
+  real a,b,c,d,det;
          
   theta[W].attachToVecMulti(Vec::REF,y,fwIndex);
   p[W].attachToVecMulti(Vec::REF,y,fnIndex);
@@ -991,7 +991,7 @@ template <class PROB, class JAC>
 bool TwopCDMMS<PROB,JAC>::yPrimeValue(const real &,const  Vec& y,Vec& yp)
 {  
   myY=&y;
-  register real a,b,c,d,det;
+  real a,b,c,d,det;
              
   theta[W].attachToVecMulti(Vec::REF,y,fwIndex);       theta[W].setStrideMulti(4);
   Dtheta[W].attachToVecMulti(Vec::REF,yp,fwIndex);     Dtheta[W].setStrideMulti(4); 
@@ -1609,7 +1609,7 @@ bool TwopCDMPP<PROB,JAC>::yPrimeValue(const real &t,const  Vec& y,Vec& yp)
 {  
   myY=&y;
   pc.adjustBC(t);
-  register real a(12345),b(12345),c(12345),d(12345),det(12345);
+  real a(12345),b(12345),c(12345),d(12345),det(12345);
              
   p[W].attachToVecMulti(Vec::REF,y,fwIndex);
   p[N].attachToVecMulti(Vec::REF,y,fnIndex);

--- a/pete/pete-2.1.0/examples/CMRVec/CMRVec.h
+++ b/pete/pete-2.1.0/examples/CMRVec/CMRVec.h
@@ -45,7 +45,7 @@ public:
   template <class RHS>
   CMRVec& operator+=(const Pete::Expression<RHS> &rhs)
   {
-    register int index=base_,end=base_+dim_;
+    int index=base_,end=base_+dim_;
     T* lhs=p_;
     for(index=base_;index<end;index++)
       {
@@ -58,7 +58,7 @@ public:
   template <class RHS>
   CMRVec& operator=(const Pete::Expression<RHS> &rhs)
   {
-    register int index=base_,end=base_+dim_;
+    int index=base_,end=base_+dim_;
     T* lhs=p_;
     for(index=base_;index<end;index++)
       {
@@ -71,7 +71,7 @@ public:
   template <class RHS>
   CMRVec& operator-=(const Pete::Expression<RHS> &rhs)
   {
-    register int index=base_,end=base_+dim_;
+    int index=base_,end=base_+dim_;
     T* lhs=p_;
     for(index=base_;index<end;index++)
       {


### PR DESCRIPTION
deprecated in C++11, removed in C++17, causing failures to compile with recent compilers: 


```
In file included from AnalyticalJacobian.cpp:1:
In file included from /Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/AnalyticalJacobian.h:6:
In file included from /Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/Jacobian.h:6:
In file included from /Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/Vec.h:6:
/Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/CMRVec.h:48:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register int index=base_,end=base_+dim_;
    ^~~~~~~~~
/Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/CMRVec.h:48:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register int index=base_,end=base_+dim_;
    ^~~~~~~~~
/Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/CMRVec.h:61:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register int index=base_,end=base_+dim_;
    ^~~~~~~~~
/Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/CMRVec.h:61:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register int index=base_,end=base_+dim_;
    ^~~~~~~~~
/Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/CMRVec.h:74:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register int index=base_,end=base_+dim_;
    ^~~~~~~~~
/Users/runner/miniforge3/conda-bld/daetk_1696641573451/work/CMRVec.h:74:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register int index=base_,end=base_+dim_;
    ^~~~~~~~~
```

It's possible to also keep it gated on pre-c++17 via a macro, but it was deprecated because it ~never does what was requested, so I suspect removing it is the right thing to do.